### PR TITLE
Encapsulate dishes

### DIFF
--- a/lib/menu.rb
+++ b/lib/menu.rb
@@ -1,6 +1,4 @@
 class Menu
-  attr_reader :dishes
-
   def initialize(dishes)
     @dishes = dishes
   end
@@ -18,4 +16,8 @@ class Menu
   def price(dish)
     dishes[dish]
   end
+
+  private
+
+  attr_reader :dishes
 end

--- a/lib/order.rb
+++ b/lib/order.rb
@@ -1,7 +1,4 @@
 class Order
-
-  attr_reader :dishes
-
   def initialize(menu)
     @dishes = {}
     @menu = menu
@@ -18,7 +15,7 @@ class Order
 
   private
 
-  attr_reader :menu
+  attr_reader :dishes, :menu
 
   def item_totals
     dishes.map do |dish, quantity|

--- a/spec/menu_spec.rb
+++ b/spec/menu_spec.rb
@@ -11,10 +11,6 @@ describe Menu do
     }
   end
 
-  it "has a list of dishes with prices" do
-    expect(menu.dishes).to eq(dishes)
-  end
-
   it "prints a list of dishes with prices" do
     printed_menu = "Chicken £3.99, Falafel £4.50"
     expect(menu.print).to eq(printed_menu)

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -21,24 +21,16 @@ describe Order do
     allow(menu).to receive(:price).with(:fish).and_return(2.50)
   end
 
-  it "selects several dishes from the menu" do
-    create_order
-    expect(order.dishes).to eq(dishes)
-  end
-
   it "doesn't allow items to be added that are not on the menu" do
     allow(menu).to receive(:has_dish?).with(:beef).and_return(false)
+
     expect { order.add(:beef, 2) }.to raise_error NoItemError, "Beef is not on the menu!"
   end
 
   it "calculates the total for the order" do
-    create_order
-    total = 8.50
-    expect(order.total).to eq(total)
-  end
-
-  def create_order
     order.add(:chicken, 2)
     order.add(:fish, 1)
+
+    expect(order.total).to eq(8.50)
   end
 end


### PR DESCRIPTION
## Why

The exemplar includes public `attr_reader :dishes` for `Menu` and `Order` which leak how dishes are stored. These readers are not used by other objects, so they are examples of testing state rather than behaviour. So let's remove them.

## What

- Make `attr_reader :dishes` private in `Menu` and `Order`.