### PR TITLE
Include necessary requirement

### DIFF
--- a/spec/sms_spec.rb
+++ b/spec/sms_spec.rb
@@ -1,4 +1,5 @@
 require "sms"
+require "time"
 
 describe SMS do
   subject(:sms) { described_class.new(config, client: client) }


### PR DESCRIPTION
Time has no parse method unless you `require "time"`

Previously:
```
$ rspec
........F....

Failures:

  1) SMS delivers an SMS with the estimated time
     Failure/Error: allow(Time).to receive(:now).and_return(Time.parse("17:52"))
     NoMethodError:
       undefined method `parse' for Time:Class
     # ./spec/sms_spec.rb:26:in `block (2 levels) in <top (required)>'

Finished in 0.01131 seconds (files took 0.20606 seconds to load)
13 examples, 1 failure

Failed examples:

rspec ./spec/sms_spec.rb:19 # SMS delivers an SMS with the estimated time
```

Now:
```
$ rspec
.............

Finished in 0.02482 seconds (files took 0.31918 seconds to load)
13 examples, 0 failures
```